### PR TITLE
Update tn-aws.md

### DIFF
--- a/content/en/hub/initial-setup/install/tn-aws.md
+++ b/content/en/hub/initial-setup/install/tn-aws.md
@@ -11,8 +11,9 @@ weight: 3
   * AWS Account
   * S3 Bucket
   * User with permissions for EC2
-    * Download the user key to the local working directory
+    * Download the user key to the local working directory and modify
   * Install bhyve and bsdec2-image-upload
+  * Patch bsdec2-image-upload if needed
 * Create TrueNAS image file
   * Download TrueNAS .iso
   * Create blank image file
@@ -20,24 +21,17 @@ weight: 3
   * Create tap and bridge interface
   * Load image and iso into bhyve
   * Install TrueNAS
-  * Reload image into bhyve
-* Configure image networking
-  * Reset network interface
-  * Create DHCP interface `xn0`
-  * Reset configuration to default
-  * Power off device
 * Upload image to EC2
   * Description and region name are required
 * Launch EC2 instance
   * Select name created with image
-  * t2.medium is the recommended instance type
-  * Add volumes as needed
+  * t2.large is the recommended instance type
+  * Add HDD/SSD volumes as needed
   * Step 6: add new rule
     * Type: `http`
-    * Source: `Custom, 0.0.0.0/0`
   * Launch the instance
 * Wait for AWS to finish status checks
-* Paste public DNS link in browser to access TrueNAS web interface
+* Paste Public DNS or Public IP link in browser to access TrueNAS web interface
 
 ## Using Virtualized TrueNAS with Amazon Web Services (AWS)
 

--- a/content/en/hub/initial-setup/install/tn-aws.md
+++ b/content/en/hub/initial-setup/install/tn-aws.md
@@ -45,9 +45,9 @@ These instructions demonstrate how to create a virtualized TrueNAS image on Free
 There are a few things that must be prepared before building the image.
 The FreeBSD system needs two applications to create, configure, and upload the virtual machine image:
 [bhyve](https://bhyve.org/)
-and [bsdec2-image-upload](https://www.freshports.org/net/bsdec2-image-upload/). The most recent version (>=1.3.1) of bsdec2-image-upload is required, otherwise an SSL error will occur when attempting to upload the image.
+and [bsdec2-image-upload](https://www.freshports.org/net/bsdec2-image-upload/). The most recent version (>=1.3.1) of bsdec2-image-upload is required, otherwise an SSL error will occur when attempting to upload the image. If not available on the ports tree, the utility will need to be downloaded from the [GitHub](https://github.com/cperciva/bsdec2-image-upload).
 
-**NOTE**: Currently bsdec2-image-upload will fail on images whose file size is not 10GB. An issue has been created, but in the meantime a patch may be needed to correct this error, which involves cloning the [project on GitHub](https://github.com/cperciva/bsdec2-image-upload) and editing main.c, replacing:
+**NOTE**: Currently bsdec2-image-upload will fail on images whose file size is not 10GB. An issue has been created, but in the meantime a patch may be needed to correct this error, which involves editing main.c, replacing:
 
 ```
 "BlockDeviceMapping.1.Ebs.VolumeSize=10&"
@@ -59,9 +59,9 @@ with
 "BlockDeviceMapping.1.Ebs.VolumeSize=16&"
 ```
 
-Following the size required for TrueNAS. To build, ensure either libressl-devel or openssl-devel is installed and run "make install".
+Following the size required for TrueNAS. To build, ensure either libressl-devel or openssl-devel, as well as ca_root_nss, are installed and run "make install". Additionally the utility only builds on FreeBSD, but another patch is underway to build on Linux.
 
-Create an [AWS account](https://portal.aws.amazon.com/billing/signup?nc2=h_ct&src=default&redirect_url=https%3A%2F%2Faws.amazon.com%2Fregistration-confirmation#/start),
+Create an [AWS account](https://portal.aws.amazon.com/billing/signup?nc2=h_ct&src=default&redirect_url=https%3A%2F%2Faws.amazon.com%2Fregistration-confirmation#/start) with an
 [S3 bucket](https://docs.aws.amazon.com/quickstarts/latest/s3backup/step-1-create-bucket.html). Record the region associated with the S3 bucket. It is also recommened the bucket have a lifetime policy which deletes data after 1 day, as bsdec2-image-upload will not delete files from S3 and the files are no longer needed after the AMI is registered.
 A [user with permissions to EC2 and S3](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html) will also be required with the following permissions:
 
@@ -103,7 +103,7 @@ ACCESS_KEY_SECRET={SECRET}
 When all the prerequisites are ready, [download a TrueNAS .iso file](https://www.freenas.org/download-freenas-release/).
 Any version from FreeNAS/TrueNAS 11.2 and later will work.
 Open a shell and go to your local working directory.
-Create an empty image file with `truncate -s 16G {TRUENAS}.img`.
+Create an empty raw image file with `truncate -s 16G {TRUENAS}.img`.
 Replace {TRUENAS} with your name for the new image file.
 We'll use this empty image as the installation target for the TrueNAS *.iso*.
 
@@ -130,32 +130,7 @@ sh /usr/share/examples/bhyve/vmrun.sh -c 2 -m 4GB -t tap0 -d {TRUENAS}.img -i -I
 ```
 
 When the TrueNAS installer opens, make sure booting with BIOS is chosen and start the installation.
-Power off the device when the installation is done.
-
-### Configure Image Networking
-
-Load the image into bhyve again:
-
-```
-bhyveload -m 4G -d {TRUENAS}.img vm0
-bhyve -c 2 -m 4G -H -A -P -g 0 -s 0,hostbridge -s 1,lpc -s 2,virtio-net,tap0 -s 3,virtio-blk, {TRUENAS}.img -l com1,stdio vm0
-```
-
-**NOTE**:
-If the following commands fail, for instance an error concerning "boot.lua", then try the following command which uses a shell script included in the bhyve installation combining the two pervious commands:
-
-```
-sh /usr/share/examples/bhyve/vmrun.sh -c 2 -m 4GB -t tap0 -d {TRUENAS}.img vm0
-```
-
-Once booted, execute the following commands to ensure network compatability with EC2:
-
-```
-Reset the network interface.
-Create a new DHCP interface named `xn0`.
-```
-
-Once completed, power off the device.
+Power off the device when the installation is done. Do not load the completed image into bhyve and boot after installation as TrueNAS will create invalid network settings (this may only be true for 12.0 onward. If network issues occur in previous versions, boot the image and create a DHCP interface manually named `xn0`).
 
 ### Upload Image to EC2
 
@@ -167,11 +142,10 @@ Replace {TRUENAS} with the image file name, {description} with a unique identifi
 All of these elements are required for the upload to start.
 
 `bsdec2-image-upload` sends the image to the AWS bucket in 10MB segments.
-The upload can take as long as an hour, depending on connection speeds and other factors.
+The upload can take several hours, depending on connection speeds and other factors.
 
 When the S3 bucket upload is complete, the script will create a snapshot, register the AMI, and copy the AMI to all regions for mirrors.
-The upload command will fail if the image doesn't work for some reason.
-For example, using a name that already exists will cause the upload command to fail.
+The upload command can fail for various reasons; for example, using a description that already exists.
 If this happens, fix the error and rerun the command.
 When successful, the upload simply finishes.
 
@@ -191,15 +165,24 @@ Find the **Launch instance** section, open the **Launch instance** drop down, an
 The instance launcher follows several steps:
 
 1. Click **My AMIs** and select the name that was uploaded by `bsdec2-image-upload`.
-2. Any instance will work, but **t2.medium** is recommended for TrueNAS.
+2. Any instance will work, but **t2.large** is recommended for TrueNAS given an 8GB memory recommendation.
 3. Skip this step.
-4. Add volumes according to your TrueNAS use case.
+4. Add EBS volumes according to your TrueNAS use case. It is reccomened to add at least a couple of Cold HDD volumes for a storage pool.
+General Purpose SSD volumes can be used as L2ARC or SLOG devices.
 5. Skip this step.
-6. Add a rule with **http** as the type and the source `Custom, 0.0.0.0/0`.
-   This allows you to connect to the TrueNAS web interface.
+6. Add a rule with **http**. This allows you to connect to the TrueNAS web interface.
 7. Review your settings and press **Launch**.
 
 The running instance is added to the EC2 dashboard or can be seen in the **Instances** menu.
 When the image has fully started, AWS performs two status checks.
 The first checks for AWS uptime, and the second makes sure your instance is in a functional state.
-When both checks have passed, you can paste the Public DNS link in a new browser window to connect to the TrueNAS web interface.
+When both checks have passed, you can paste either Public IP or Public DNS link in a new browser window to connect to the TrueNAS web interface.
+
+## TrueNAS Community AMI
+
+Starting with 12.0-BETA, an AMI will be created each release and is available in the Community AMI section. When using this AMI, login with the default credentials:
+
+Username: root
+Password: abcd1234
+
+**WARNING**: Please change the password as after initial login. 


### PR DESCRIPTION
Ran through this guide after ~14 months and found some areas didn't work and some were out of date.

Changes:
bsdec2-image-upload has been updated from 1.2.2 to 1.3.1. The new version is required to avoid SSL errors on upload. 1.3.1 is listed on freshports but not in the FreeBSD ports tree. Included instructions on how to build, as well as a manual patch.
KEY.pem needs to be created manually as IAM keys are csv.
Included details about which user permissions are needed as well as S3 bucket settings.
The two bhyve commands failed for me. Included alternate plan that combines the two and uses a shell script that comes with bhyve.
Expanded on the required network changes for the EC2 instance to be reachable.