### PR TITLE
DOCS-813 make version drop down more clear.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -118,13 +118,13 @@ products = "products"
 fullversion = "TrueNAS 12.0-BETA1"
 version = "TN 12.0-BETA1"
 githubbranch = "master"
-url = "./"
+url = "/"
 
 [[params.versions]]
 fullversion = "TrueNAS 11.3"
 version = "TN 11.3"
 githubbranch = "TN11-3"
-url = "https://docs.ixsystems.com/hub/additional-topics/legacy/tn-legacy/"
+url = "/hub/additional-topics/legacy/tn-legacy/"
 
 # User interface configuration
 [params.ui]

--- a/config.toml
+++ b/config.toml
@@ -116,7 +116,7 @@ products = "products"
 # Entries for the "Version" dropdown
 [[params.versions]]
 fullversion = "TrueNAS 12.0-BETA1"
-version = "TN 12.0-BETA1"
+version = "Current"
 githubbranch = "master"
 url = "/"
 


### PR DESCRIPTION
Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.

I found a way to leave the 11.3 entry in the list. But now it is more clear. Links are relative so you don't get that issue of not changing a page when switching between 11.3 and 12.0