### PR TITLE
DOCS-834: Remove obsolete "lightlink" rules

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -192,32 +192,6 @@ $secondary: #666666;
   border-color: #1EAEDB;
 }
 
-
-// Links styled for grey background
-.lightlink {
-  color: #66b3ff;
-}
-
-.lightlink:visited {
-  color: pink;
-  background-color: transparent;
-  text-decoration: none;
-}
-
-.lightlink:hover {
-  color: #3399ff;
-  background-color: transparent;
-  text-decoration: underline;
-}
-
-.lightlink:active {
-  color: yellow;
-  background-color: transparent;
-  text-decoration: underline;
-}
-
-
-
 .h2 .frontcenter {
 	text-align: center;
 }

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -17,10 +17,10 @@ linkTitle = "TrueNAS Docs"
       <h3>Learn About TrueNAS</h3>
       <p>Background information and general overview of the software.</p>
       <p>
-        <a class="lightlink" href="/hub/intro/whatis/">What is TrueNAS?</a><br>
+        <a href="/hub/intro/whatis/">What is TrueNAS?</a><br>
         <a href="https://www.ixsystems.com/blog/hardware-guide/">Hardware Requirements</a><br>
-        <a class="lightlink" href="/hub/intro/truenas-roadmap/">Release Schedule</a><br>
-        <a class="lightlink" href="/hub/intro/release-notes/">Release Notes</a><br>
+        <a href="/hub/intro/truenas-roadmap/">Release Schedule</a><br>
+        <a href="/hub/intro/release-notes/">Release Notes</a><br>
       </p>  
       <p class="button-wrapper"><a class="linkbutton" href="/hub/intro/">Overview</a></p>
     </div>


### PR DESCRIPTION
- Remove obsolete css for links on grey backgrounds (site styling went a different direction)
- Review front page and remove references to obsolete lightlink rules



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
