### PR TITLE
Fix COW link typo

### DIFF
--- a/content/en/hub/additional-topics/reference/ZFS-references.md
+++ b/content/en/hub/additional-topics/reference/ZFS-references.md
@@ -16,7 +16,7 @@ provide continued, collaborative development of the open source version.
 Here is an overview of the features provided by ZFS:
 
 **ZFS is a transactional, Copy-On-Write**
-([COW](<https://en.wikipedia.org/wiki/ZFS#Copy-on-write_transactional_model))
+([COW](https://en.wikipedia.org/wiki/ZFS#Copy-on-write_transactional_model))
 filesystem. For each write request, a copy is made of the associated
 disk blocks and all changes are made to the copy rather than to the
 original blocks. When the write is complete, all block pointers are


### PR DESCRIPTION
Erroneous left caret inside markdown for COW link.



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
