### PR TITLE
Update iscsi-share.md

### DIFF
--- a/content/en/hub/sharing/iscsi/iscsi-share.md
+++ b/content/en/hub/sharing/iscsi/iscsi-share.md
@@ -69,7 +69,7 @@ enabled on both the client and server.
 
 
 To get started, make sure a
-<a href="/hub/intitial-setup/storage/datasets/">dataset has been created</a>
+<a href="/hub/initial-setup/storage/datasets/">dataset has been created</a>
 with at least one file to share, or a
 <a href="/hub/initial-setup/storage/zvols/">zvol has been created</a>.
 If the desired file or zvol already exists, proceed to turning on the


### PR DESCRIPTION
Fixed the dataset link to <a href="/hub/initial-setup/storage/datasets/>. The word initial was misspelled in the old one (/hub/intitial-setup/storage/datasets/")



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
