### PR TITLE
Update afp-share.md

### DIFF
--- a/content/en/hub/sharing/afp/afp-share.md
+++ b/content/en/hub/sharing/afp/afp-share.md
@@ -6,8 +6,11 @@ tags: ["networking","afp"]
 
 Apple Filing Protocol (AFP) is a network protocol that allows file sharing over a network. It's similar to SMB and NFS. However, it was made to work flawlessly on Apple systems. In this document, you will learn how to create and connect to a general purpose AFP share.
 
-{{% alert title="The AFP protocol has been deprecated by Apple" %}}
-Beginning in 2013, Apple began using the SMB sharing protocol as the default option for file sharing and ceased development of the AFP sharing protocol. It is recommended to use SMB sharing over AFP unless files will be shared with legacy Apple products. For further information please read https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/APFS_Guide/FAQ/FAQ.html
+{{% pageinfo %}}
+The AFP protocol has been deprecated by Apple
+{{% /pageinfo %}}
+
+Beginning in 2013, Apple began using the SMB sharing protocol as the default option for file sharing and ceased development of the AFP sharing protocol. It is recommended to use SMB sharing over AFP unless files will be shared with legacy Apple products. For further information please read: https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/APFS_Guide/FAQ/FAQ.html
 
 To get started, make sure a <a href="/hub/initial-setup/storage/datasets">dataset has been created</a>. This dataset serves as share data storage. If a dataset already exists, proceed to turning on the AFP service.
 

--- a/content/en/hub/sharing/afp/afp-share.md
+++ b/content/en/hub/sharing/afp/afp-share.md
@@ -6,7 +6,20 @@ tags: ["networking","afp"]
 
 Apple Filing Protocol (AFP) is a network protocol that allows file sharing over a network. It's similar to SMB and NFS. However, it was made to work flawlessly on Apple systems. In this document, you will learn how to create and connect to a general purpose AFP share.
 
+{{% alert title="The AFP protocol has been deprecated by Apple" %}}
+Beginning in 2013, Apple began using the SMB sharing protocol as the default option for file sharing and ceased development of the AFP sharing protocol. It is recommended to use SMB sharing over AFP unless files will be shared with legacy Apple products. For further information please read https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/APFS_Guide/FAQ/FAQ.html
+
 To get started, make sure a <a href="/hub/initial-setup/storage/datasets">dataset has been created</a>. This dataset serves as share data storage. If a dataset already exists, proceed to turning on the AFP service.
+
+## AFP Share
+
+Go to **Sharing > Apple Shares (AFP)** and click *ADD* to create an AFP share.You will need to confirm that you want to Continue with AFP set up.
+Next, use the file browser and select a dataset to share. Enter a descriptive name for the share. If this share is is to be used for Time Machine backups, set *Time Machine*. This advertises the share as a disk for other Mac systems to use as storage for Time Machine backups. It is not recommended to have multiple AFP shares configured for Time Machine backups. If desired, you can set *Use as Home Share*. When this setting is enabled, users that connect to the share have home directories created for them. Only one share can be used as a home share. At the time of creation, the AFP share is enabled by default. If you wish to create the share but not immediately enable it, unset the *Enable* checkbox. 
+Clicking *SUBMIT* creates the share.
+
+Opening the *ADVANCED OPTIONS* allows you to modify the shares permissions, add a description, and specify auxillary parameters.
+
+Existing AFP shares can be edited by going to **Sharing > Apple Shares (AFP)** and clicking <i class="fas fa-ellipsis-v" aria-hidden="true" title="Options"></i>.
 
 ## AFP Service
 
@@ -14,16 +27,6 @@ To turn the AFP service on, go to **Services** and click the slider for *AFP*. I
 The AFP share does not work if the service is not turned on.
 
 The AFP service settings can be configured by clicking <i class="fas fa-ellipsis-v" aria-hidden="true" title="Options"></i>. Don't forget to click *SAVE* when changing the settings. Unless a specific setting is needed, it is recommended to use the default settings for the AFP service.
-
-## AFP Share
-
-Go to **Sharing > Apple Shares (AFP)** and click *ADD* to create an AFP share.
-Next, use the file browser and select a dataset to share. Enter a descriptive name for the share. If this share is is to be used for Time Machine backups, set *Time Machine*. This advertises the share as a disk for other Mac systems to use as storage for Time Machine backups. It is not recommended to have multiple AFP shares configured for Time Machine backups. If desired, you can set *Use as Home Share*. When this setting is enabled, users that connect to the share have home directories created for them. Only one share can be used as a home share. At the time of creation, the AFP share is enabled by default. If you wish to create the share but not immediately enable it, unset the *Enable* checkbox. 
-Clicking *SUBMIT* creates the share.
-
-Opening the *ADVANCED OPTIONS* allows you to modify the shares permissions, add a description, and specify auxillary parameters.
-
-Existing AFP shares can be edited by going to **Sharing > Apple Shares (AFP)** and clicking <i class="fas fa-ellipsis-v" aria-hidden="true" title="Options"></i>.
 
 ## Connecting to the AFP Share
 


### PR DESCRIPTION
Moved Share creation to before activating the AFP service, added the AFP depreciation warning, and added a link to the related Apple document about AFP depreciation



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
