### PR TITLE
DOCS-1451 - Clarify that the destination of a Replication task will be a dataset

### DIFF
--- a/content/en/hub/tasks/scheduled/replication/remote-ssh.md
+++ b/content/en/hub/tasks/scheduled/replication/remote-ssh.md
@@ -67,9 +67,11 @@ Local sources can also use a naming schema to identify any custom snapshots to i
 
 The destination is where replicated snapshots are stored.
 Choosing a remote destination requires an SSH connection to that system.
-Expanding the directory browser shows the current datasets or zvols that are available for replication.
-You can select a destination or manually type a path in the field.
+Expanding the directory browser shows the current datasets that are available for replication.
+You can select a destination dataset or manually type a path in the field.
 Adding a name to the end of the path creates a new dataset in that location.
+
+<NOTE: Zvols can not be used as a remote destination for a Replication Task.
 
 <img src="/images/TasksReplicationTasksAddRemoteDest.png">
 <br><br>

--- a/content/en/hub/tasks/scheduled/replication/remote-ssh.md
+++ b/content/en/hub/tasks/scheduled/replication/remote-ssh.md
@@ -69,13 +69,11 @@ The destination is where replicated snapshots are stored.
 Choosing a remote destination requires an SSH connection to that system.
 Expanding the directory browser shows the current datasets that are available for replication.
 You can select a destination dataset or manually type a path in the field.
+Zvols cannot be used as a remote replication destination.
 Adding a name to the end of the path creates a new dataset in that location.
-
-<NOTE: Zvols can not be used as a remote destination for a Replication Task.
 
 <img src="/images/TasksReplicationTasksAddRemoteDest.png">
 <br><br>
-
 
 ### Security and Task Name
 


### PR DESCRIPTION
Clarify that a dataset is used for the remote destination of  Replication task and that zvols are not to be used



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
