### PR TITLE
Update lagg.md

### DIFF
--- a/content/en/hub/initial-setup/networking/lagg.md
+++ b/content/en/hub/initial-setup/networking/lagg.md
@@ -11,7 +11,7 @@ To set up a LAGG interface, go to **Network > Interface > Add**.
 <img src="/images/tn-add-lagg-interface.png">
 <br><br>
 
-Set **Type** to *Link Aggregation*
+Set **Type** to *Link Aggregation*.
 
 Enter a name for the interface. The name must use the format, *laggX*, where *X* is a number representing a non-parent interface.
 It is also recommended to add any notes or reminders about this particular LAGG in the **Description**.

--- a/content/en/hub/initial-setup/networking/lagg.md
+++ b/content/en/hub/initial-setup/networking/lagg.md
@@ -13,7 +13,7 @@ To set up a LAGG interface, go to **Network > Interface > Add**.
 
 Set **Type** to *Link Aggregation*
 
-Enter a name for the interface. The name must use the format, *laggX*, *vlanX*, or *bridgeX*, where *X* is a number representing a non-parent interface.
+Enter a name for the interface. The name must use the format, *laggX*, where *X* is a number representing a non-parent interface.
 It is also recommended to add any notes or reminders about this particular LAGG in the **Description**.
 
 Under LAGG Settings, set the **Lagg Protocol** to configure the interface ports to match your networking needs:


### PR DESCRIPTION
LAGGs should not be named as vlans or bridges



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
